### PR TITLE
version bump

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-xhr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/philopon/purescript-xhr",
   "description": "XMLHttpRequest",
   "keywords": [


### PR DESCRIPTION
I use purescript-xhr as dependency and need newest version (with rawBody). It seems that bower needs versioned tag for that.
